### PR TITLE
Add CI workflow using Github Actions

### DIFF
--- a/.github/workflows/lambaa-ci.yml
+++ b/.github/workflows/lambaa-ci.yml
@@ -22,4 +22,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
+    - run: npm run lint
     - run: npm test
+    - run: npm run coverage

--- a/.github/workflows/lambaa-ci.yml
+++ b/.github/workflows/lambaa-ci.yml
@@ -1,0 +1,25 @@
+name: Lambaa CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
This adds the beginning of a CI workflow for Lambaa using Github Actions.  This should build, lint, run tests and coverage.  If this works alright, we could consider also automating publishing the package.