### PR TITLE
Feature: add proxy mode

### DIFF
--- a/src/RouteMap.ts
+++ b/src/RouteMap.ts
@@ -1,8 +1,11 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+
 type RouteProperties =
     | {
           eventType: "API_GATEWAY"
           method: string
           resource: string
+          proxy: boolean
           basePath?: string
       }
     | {
@@ -43,6 +46,16 @@ export default class RouteMap {
         if (route.eventType === "API_GATEWAY") {
             route.resource = this.normalizePath(route.resource)
 
+            // on proxy we match event.resource to the url pattern
+            if(route.proxy){
+                for (const [key, routeKey] of this.map.entries()) {
+                    if (this.isPathMatch(route.resource, key, route.event)) {
+                        return routeKey;
+                    }
+                }
+            }
+
+            // if no proxy map based on resource + method
             if (route.basePath && route.resource.includes(route.basePath)) {
                 route.basePath = this.normalizePath(route.basePath)
 
@@ -57,6 +70,41 @@ export default class RouteMap {
         } else if (route.eventType === "SQS") {
             return this.map.get(route.arn)
         }
+    }
+
+    private isPathMatch(
+        eventPath: string,
+        route: string,
+        event: APIGatewayProxyEvent | null
+    ): boolean {
+        const eventPathParts = eventPath.split("/")
+        const routePathParts = route.split("_")[0].split("/")
+
+        // Fail fast if they're not the same length
+        if (eventPathParts.length !== routePathParts.length) {
+            return false
+        }
+
+        // Start with 1 because the url should always start with the first back slash
+        for (let i = 1; i < eventPathParts.length; ++i) {
+            const pathPart = eventPathParts[i]
+            const routePart = routePathParts[i]
+
+            // If the part is a curly braces value
+            const pathPartMatch = /\{(\w+)}/g.exec(routePart)
+            if (pathPartMatch) {
+                if (event?.pathParameters) {
+                    event.pathParameters[pathPartMatch[1]] = pathPart
+                }
+                continue
+            }
+
+            // Fail fast if a part doesn't match
+            if (routePart !== pathPart) {
+                return false
+            }
+        }
+        return true
     }
 
     private normalizePath(part: string): string {

--- a/src/RouteMap.ts
+++ b/src/RouteMap.ts
@@ -65,10 +65,14 @@ export default class RouteMap {
      * Get the name of the method which can handle this route but also
      * overrides event.pathParameters based on data extracted from the url
      */
-    public getRouteOverridePathParams(event: APIGatewayProxyEvent): string | undefined{
+    public getRouteOverridePathParams({event, basePath}: {
+        event: APIGatewayProxyEvent,
+        basePath: string | undefined
+    }): string | undefined{
         for (const [controllerPathKey, controllerKey] of this.map.entries()) {
             // isPathMatch overrides the current event.pathParams
-            if (this.isPathMatch(controllerPathKey, event)) {
+            const controllerComposedPath = basePath ? `${this.normalizePath(basePath)}${controllerPathKey}`: controllerPathKey;
+            if (this.isPathMatch(controllerComposedPath, event)) {
                 return controllerKey;
             }
         }

--- a/src/RouteMap.ts
+++ b/src/RouteMap.ts
@@ -66,10 +66,10 @@ export default class RouteMap {
      * overrides event.pathParameters based on data extracted from the url
      */
     public getRouteOverridePathParams(event: APIGatewayProxyEvent): string | undefined{
-        for (const [key, routeKey] of this.map.entries()) {
+        for (const [controllerPathKey, controllerKey] of this.map.entries()) {
             // isPathMatch overrides the current event.pathParams
-            if (this.isPathMatch(key, event)) {
-                return routeKey;
+            if (this.isPathMatch(controllerPathKey, event)) {
+                return controllerKey;
             }
         }
     }
@@ -77,6 +77,7 @@ export default class RouteMap {
     /**
      * Checks if the event.path matches one the url patterns avaible on
      * the controller map.
+     * TODO: allow snake cased pattern match
      */
     private isPathMatch(
         route: string,

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -39,7 +39,7 @@ class Router {
      * @param event The SQS event.
      * @param context The Lambda context.
      */
-    public route(event: SQSEvent, context: Context, proxy: false): Promise<void>
+    public route(event: SQSEvent, context: Context): Promise<void>
 
     public async route<TEvent, TResult>(
         event: TEvent,

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -67,7 +67,10 @@ class Router {
                 let debugMessage: string | undefined
 
                 if (isApiGatewayProxyEvent(event)){
-                    method = routeMap?.getRouteOverridePathParams(event);
+                    method = routeMap?.getRouteOverridePathParams({
+                        event,
+                        basePath: controllerOptions.basePath
+                    });
                     if (method) {
                         debugMessage = `Passing ${event.httpMethod} ${event.path} request to ${controller?.constructor?.name}.${method}(...)`
                     }

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -11,7 +11,7 @@ export const isApiGatewayProxyEvent = (
     event: unknown
 ): event is APIGatewayProxyEvent => {
     const e = event as APIGatewayProxyEvent
-    return e.resource?.includes("{+proxy}");
+    return e.resource?.includes("{proxy+}");
 }
 
 export const isSqsEvent = (event: unknown): event is SQSEvent => {

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -11,7 +11,7 @@ export const isApiGatewayProxyEvent = (
     event: unknown
 ): event is APIGatewayProxyEvent => {
     const e = event as APIGatewayProxyEvent
-    return e.resource.includes("{+proxy}");
+    return e.resource?.includes("{+proxy}");
 }
 
 export const isSqsEvent = (event: unknown): event is SQSEvent => {

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -7,6 +7,13 @@ export const isApiGatewayEvent = (
     return e.resource !== undefined && e.httpMethod !== undefined
 }
 
+export const isApiGatewayProxyEvent = (
+    event: unknown
+): event is APIGatewayProxyEvent => {
+    const e = event as APIGatewayProxyEvent
+    return e.resource.includes("{+proxy}");
+}
+
 export const isSqsEvent = (event: unknown): event is SQSEvent => {
     const e = event as SQSEvent
     return (

--- a/tests/parsing.tests.ts
+++ b/tests/parsing.tests.ts
@@ -4,7 +4,7 @@ import FromQuery from "../src/decorators/FromQuery"
 import FromBody from "../src/decorators/FromBody"
 import FromHeader from "../src/decorators/FromHeader"
 import Router from "../src/Router"
-import { createLambdaContext, createAPIGatewayEvent } from "./testUtil"
+import { createLambdaContext, createAPIGatewayEvent , createAPIGatewayProxyEvent} from "./testUtil"
 import { expect } from "chai"
 import RequestError from "../src/RequestError"
 import Controller from "../src/decorators/Controller"
@@ -15,6 +15,15 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda"
 class TestController {
     @Route("GET", "from_path_test")
     public async fromPathTest(@FromPath("test") test: string) {
+        return {
+            statusCode: 200,
+            body: test,
+        }
+    }
+
+    // sorry about this, our proxy implementation doesn't not support snake cased urls at the moment
+    @Route("GET", "from-path-proxy-test/{test}")
+    public async fromPathProxyTest(@FromPath("test") test: string) {
         return {
             statusCode: 200,
             body: test,
@@ -84,6 +93,19 @@ const router = new Router({ controllers: [new TestController()] })
 const context = createLambdaContext()
 
 describe("request parsing tests", () => {
+
+    it("extracts path parameter from proxy request", async () => {
+        const event = createAPIGatewayProxyEvent({
+            path: "/from-path-proxy-test/test_path_param",
+            method: "GET",
+        })
+
+        const response = await router.route(event, context)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.body).to.equal("test_path_param")
+    })
+    
     it("extracts path parameter from request", async () => {
         const event = createAPIGatewayEvent({
             resource: "from_path_test",

--- a/tests/routing.tests.ts
+++ b/tests/routing.tests.ts
@@ -17,6 +17,7 @@ import Router from "../src/Router"
 import {
     createLambdaContext as createLambdaContext,
     createAPIGatewayEvent,
+    createAPIGatewayProxyEvent,
     createSQSEvent,
 } from "./testUtil"
 import { expect } from "chai"
@@ -285,7 +286,7 @@ describe("routing tests", () => {
             expect(response.body).to.equal("test8")
         })
 
-        it("rotues when base path route has leading /", async () => {
+        it("routes when base path route has leading /", async () => {
             const event = createAPIGatewayEvent({
                 resource: "/test/9",
                 method: "GET",
@@ -300,6 +301,18 @@ describe("routing tests", () => {
         it("routes when base path route has no leading /", async () => {
             const event = createAPIGatewayEvent({
                 resource: "/test/10",
+                method: "GET",
+            })
+
+            const response = await handler(event, context)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.body).to.equal("test10")
+        })
+
+        it("routes when basePath is included on proxy event", async () => {
+            const event = createAPIGatewayProxyEvent({
+                path: "/test/10",
                 method: "GET",
             })
 

--- a/tests/testUtil.ts
+++ b/tests/testUtil.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { APIGatewayProxyEvent, Context, SQSEvent } from "aws-lambda"
+import { APIGatewayEventFactoryArgs } from "./types";
 
 export const createAPIGatewayEvent = ({
     body,
@@ -8,14 +9,7 @@ export const createAPIGatewayEvent = ({
     pathParameters,
     queryStringParameters,
     headers,
-}: {
-    body?: string
-    resource?: string
-    method?: string
-    pathParameters?: { [name: string]: string }
-    queryStringParameters?: { [name: string]: string }
-    headers?: { [name: string]: string }
-} = {}): APIGatewayProxyEvent => {
+}: APIGatewayEventFactoryArgs = {}): APIGatewayProxyEvent => {
     const eventTemplate: APIGatewayProxyEvent = {
         resource: resource ?? "/test",
         path: "/v1",
@@ -67,11 +61,11 @@ export const createAPIGatewayEvent = ({
     return eventTemplate
 }
 
-export const createAPIGatewayProxyEvent = (args: any) => {
+export const createAPIGatewayProxyEvent = (args: APIGatewayEventFactoryArgs): APIGatewayProxyEvent => {
     const event = createAPIGatewayEvent(args)
     return {
         ...event,
-        path: args.path,
+        path: args.path as string,
         pathParameters: {},
         resource: '{proxy+}'
     }

--- a/tests/testUtil.ts
+++ b/tests/testUtil.ts
@@ -67,6 +67,15 @@ export const createAPIGatewayEvent = ({
     return eventTemplate
 }
 
+export const createAPIGatewayProxyEvent = (args: any) => {
+    const event = createAPIGatewayEvent(args)
+    return {
+        ...event,
+        path: args.path,
+        resource: '{+proxy}'
+    }
+}
+
 export const createSQSEvent = (...arns: string[]): SQSEvent => ({
     Records: arns.map((arn) => ({
         eventSourceARN: arn,

--- a/tests/testUtil.ts
+++ b/tests/testUtil.ts
@@ -73,7 +73,7 @@ export const createAPIGatewayProxyEvent = (args: any) => {
         ...event,
         path: args.path,
         pathParameters: {},
-        resource: '{+proxy}'
+        resource: '{proxy+}'
     }
 }
 

--- a/tests/testUtil.ts
+++ b/tests/testUtil.ts
@@ -72,6 +72,7 @@ export const createAPIGatewayProxyEvent = (args: any) => {
     return {
         ...event,
         path: args.path,
+        pathParameters: {},
         resource: '{+proxy}'
     }
 }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,0 +1,9 @@
+export interface APIGatewayEventFactoryArgs {
+    body?: string
+    resource?: string
+    method?: string
+    pathParameters?: { [name: string]: string }
+    queryStringParameters?: { [name: string]: string }
+    headers?: { [name: string]: string },
+    path?: string
+}


### PR DESCRIPTION
## Description

Add the possibility to use `lambaa` along with `AGW` in proxy mode. That means the `event.resource` will no longer contain the path, that's gonna be avaible from `event.path`

## Benefits

For projects that are not using `serverless` adding a new controller endpoint would require to apply infra from devops.

## Shortcommings

One of the main issues when mapping the routes completely inside the lambda, is that we loose the benefit of having the `event.pathParamaters` populated. We have to reinject them into the event payload so `fromPath` decorators still work.

The current implementation does not support snake cased urls. This is a `TODO`.