### PR TITLE
fix method distinction

### DIFF
--- a/src/RouteMap.ts
+++ b/src/RouteMap.ts
@@ -88,10 +88,11 @@ export default class RouteMap {
         event: APIGatewayProxyEvent
     ): boolean {
         const eventPathParts = event.path.split("/")
+        const routeMethod = route.split("_")[1];
         const routePathParts = route.split("_")[0].split("/")
 
         // Fail fast if they're not the same length
-        if (eventPathParts.length !== routePathParts.length) {
+        if (eventPathParts.length !== routePathParts.length || routeMethod !== event.httpMethod) {
             return false
         }
 

--- a/tests/routing.tests.ts
+++ b/tests/routing.tests.ts
@@ -134,6 +134,22 @@ class TestController3 {
             body: "test10",
         }
     }
+
+    @API("PUT", "10")
+    public async test10PUT(): Promise<APIGatewayProxyResult> {
+        return {
+            statusCode: 200,
+            body: "test10PUT",
+        }
+    }
+
+    @API("POST", "10")
+    public async test10POST(): Promise<APIGatewayProxyResult> {
+        return {
+            statusCode: 200,
+            body: "test10POST",
+        }
+    }
 }
 
 const router = new Router({
@@ -320,6 +336,30 @@ describe("routing tests", () => {
 
             expect(response.statusCode).to.equal(200)
             expect(response.body).to.equal("test10")
+        })
+
+        it("routes PUT method when basePath is included on proxy event", async () => {
+            const event = createAPIGatewayProxyEvent({
+                path: "/test/10",
+                method: "PUT",
+            })
+
+            const response = await handler(event, context)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.body).to.equal("test10PUT")
+        })
+
+        it("routes POST method when basePath is included on proxy event", async () => {
+            const event = createAPIGatewayProxyEvent({
+                path: "/test/10",
+                method: "POST",
+            })
+
+            const response = await handler(event, context)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.body).to.equal("test10POST")
         })
     })
 


### PR DESCRIPTION
### Description

There's a bug in the `proxyEvent` mode that will fallback to the first route found when multiple  routes have the same `path` but with different methods. E.g: `GET /test/10` and `PUT /test/10` would always fallback to `GET /test/10`