### PR TITLE
Add middleware context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lambaa",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "description": "A small framework, with very few dependencies to help build API's using AWS API Gateway & Lambda.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -20,13 +20,12 @@ import {
     isScheduledEvent,
     isDynamoDbStreamEvent,
 } from "./typeGuards"
-import { ControllerOptions, Handler, MiddlewarePipeline } from "./types"
-
-type Destination = {
-    controller: any
-    method: string
-    options: ControllerOptions
-}
+import {
+    ControllerOptions,
+    Destination,
+    Handler,
+    MiddlewarePipeline,
+} from "./types"
 
 export default class Router {
     private middleware: MiddlewarePipeline<any, any> = []

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -20,12 +20,13 @@ import {
     isScheduledEvent,
     isDynamoDbStreamEvent,
 } from "./typeGuards"
-import {
-    ControllerOptions,
-    Destination,
-    Handler,
-    MiddlewarePipeline,
-} from "./types"
+import { ControllerOptions, Handler, MiddlewarePipeline } from "./types"
+
+interface Destination {
+    controller: any
+    method: string
+    options: ControllerOptions
+}
 
 export default class Router {
     private middleware: MiddlewarePipeline<any, any> = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,6 @@ import {
     APIGatewayProxyResult,
 } from "aws-lambda"
 
-export interface MiddlewareContext {
-    controller?: any
-    method?: string
-}
-
 export interface RequestOptions {
     required: boolean
 }
@@ -72,6 +67,11 @@ export type Handler<
 export type MiddlewarePipeline<TEvent = unknown, TResult = unknown> = Array<
     Middleware<TEvent, TResult> | MiddlewareFunction<TEvent, TResult>
 >
+
+export interface MiddlewareContext {
+    controller?: any
+    method?: string
+}
 
 export interface Destination {
     controller: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,3 +72,9 @@ export type Handler<
 export type MiddlewarePipeline<TEvent = unknown, TResult = unknown> = Array<
     Middleware<TEvent, TResult> | MiddlewareFunction<TEvent, TResult>
 >
+
+export interface Destination {
+    controller: any
+    method: string
+    options: ControllerOptions
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,11 @@ import {
     APIGatewayProxyResult,
 } from "aws-lambda"
 
+export interface MiddlewareContext {
+    controller?: any
+    method?: string
+}
+
 export interface RequestOptions {
     required: boolean
 }
@@ -32,7 +37,8 @@ export type MiddlewareFunction<
 > = (
     event: TEvent,
     context: Context,
-    next: Handler<TEvent, TResult>
+    next: Handler<TEvent, TResult>,
+    middlewareContext?: MiddlewareContext
 ) => Promise<TResult>
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,9 +72,3 @@ export interface MiddlewareContext {
     controller?: any
     method?: string
 }
-
-export interface Destination {
-    controller: any
-    method: string
-    options: ControllerOptions
-}

--- a/tests/middleware.tests.ts
+++ b/tests/middleware.tests.ts
@@ -529,4 +529,26 @@ describe("middleware tests", () => {
             expect(events.shift()).to.be.undefined
         })
     })
+
+    it("receives middleware context", async () => {
+        const event = createAPIGatewayEvent({
+            method: "GET",
+            resource: "testControllerWithNoMiddleware1Ping1",
+        })
+
+        const router = new Router()
+            .registerController(new TestControllerWithNoMiddleware1())
+            .registerMiddleware(
+                async (event, context, next, middlewareContext) => {
+                    expect(middlewareContext).to.exist
+                    expect(middlewareContext?.controller).to.exist
+                    expect(middlewareContext?.method).to.equal("ping1")
+                    return next(event, context)
+                }
+            )
+
+        const response = await router.route(event, context)
+
+        expect(response.statusCode).to.equal(200)
+    })
 })


### PR DESCRIPTION
Add additional optional argument for middleware context.
```typescript
interface MiddlewareContext {
    controller?: any
    method?: string
}
```

This can allow us to write extensions such as decorators that add custom metadata. We can then access this metadata in middleware.

```typescript
const middleware: MiddlewareFunction = async (
    event,
    context,
    next,
    middlewareContext
) => {
    const controllerMetatdata = Reflect.getMetadata(
        "key",
        middlewareContext?.controller
    )

    const methodMetadata = Reflect.getMetadata(
        "key",
        middlewareContext?.controller,
        middlewareContext?.method
    )

    return next(event, context)
}
```